### PR TITLE
Update with last changes on master (#143)

### DIFF
--- a/.github/workflows/build-pac.yml
+++ b/.github/workflows/build-pac.yml
@@ -1,0 +1,74 @@
+on:
+  push:
+    branches:
+    - public_analysis_content
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+  BRANCH: "public_analysis_content"
+  PYTHON_VERSION: "3.7"
+  PYTHON_SHORT_VERSION: "cp37-cp37m"
+  PYTHON_WHEEL_VERSION: "cp37-abi3"
+  PYTHON_FULL_VERSION: "3.7.13"
+  QT_VERSION_MAJOR: "5"
+  QT_VERSION_MINOR: "15"
+  QT_VERSION_PATCH: "2"
+  QT_VERSION: "5.15"
+  QT_FULL_VERSION: "5.15.2"
+  PYSIDE_VERSION: "2"
+  LLVM_VERSION: "14.0.6"
+  GCC_VERSION: "10.1.0"
+
+
+jobs:
+
+
+  manylinux_2_28_with_qt_and_pyside:
+    name: "Build the manylinux_2_28_with_qt_and_pyside image necessary for lima-python"
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Checkout code"
+        uses: actions/checkout@v2
+
+      #- name: "Free disk space"
+        #run: bash ./free-diskspace.sh
+
+      - name: "Build image"
+        run: cd ./continuous_integration && docker build --progress=plain -f Dockerfile-manylinux_2_28_with_qt_and_pyside --build-arg BRANCH="${BRANCH}" --build-arg GCC_VERSION="${GCC_VERSION}" --build-arg LLVM_VERSION="${LLVM_VERSION}" --build-arg QT_FULL_VERSION="${QT_FULL_VERSION}" --build-arg QT_VERSION_MAJOR="${QT_VERSION_MAJOR}" --build-arg QT_VERSION_MINOR="${QT_VERSION_MINOR}" --build-arg QT_VERSION_PATCH="${QT_VERSION_PATCH}" --build-arg QT_VERSION="${QT_VERSION}" --build-arg PYSIDE_VERSION="${PYSIDE_VERSION}" --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PYTHON_SHORT_VERSION=${PYTHON_SHORT_VERSION} --build-arg PYTHON_FULL_VERSION=${PYTHON_FULL_VERSION} -t aymara/manylinux_2_28_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest .
+
+      - name: "Push image"
+        run: docker push aymara/manylinux_2_28_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest
+
+  manylinux_2_28_lima-manylinux:
+    name: "Build the manylinux_2_28_lima-manylinux image necessary for lima-python"
+    needs: manylinux_2_28_with_qt_and_pyside
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Checkout code"
+        uses: actions/checkout@v2
+
+      - name: "Build image"
+        run: cd ./continuous_integration && docker build -f Dockerfile-manylinux_2_28_lima-manylinux --build-arg BRANCH="${BRANCH}" --build-arg GCC_VERSION="${GCC_VERSION}" --build-arg LLVM_VERSION="${LLVM_VERSION}" --build-arg QT_FULL_VERSION="${QT_FULL_VERSION}" --build-arg QT_VERSION_MAJOR="${QT_VERSION_MAJOR}" --build-arg QT_VERSION_MINOR="${QT_VERSION_MINOR}" --build-arg QT_VERSION_PATCH="${QT_VERSION_PATCH}" --build-arg QT_VERSION="${QT_VERSION}" --build-arg PYSIDE_VERSION="${PYSIDE_VERSION}" --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PYTHON_SHORT_VERSION=${PYTHON_SHORT_VERSION} --build-arg PYTHON_FULL_VERSION=${PYTHON_FULL_VERSION} -t aymara/lima-manylinux_2_28-qt${QT_VERSION}-python${PYTHON_VERSION}:latest .
+
+      - name: "Push image"
+        run: docker push aymara/lima-manylinux_2_28-qt${QT_VERSION}-python${PYTHON_VERSION}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-    - deeplima-lemmatizer-dev
     - master
 
 env:

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ LIMA - Libre Multilingual Analyzer
 
 # TL;DR
 
-Under GNU/Linux with python >= 3.7 and <= 3.9:
+Under Linux with python >= 3.7 and < 4:
 
 ```bash
 # Upgrading pip is fundamental in order to obtain the correct LIMA version
 $ pip install --upgrade pip
-$ pip install aymara==0.4.0
+$ pip install aymara==0.4.1
 $ lima_models.py -l eng
 $ python
 >>> import aymara.lima
->>> l = aymara.lima.Lima("ud-eng")
->>> sentences = l.analyzeText('Hello, World!', lang="ud-eng")
+>>> nlp = aymara.lima.Lima("ud-eng")
+>>> sentences = nlp('Hello, World!')
 >>> print(sentences[0][0].lemma)
 hello
 >>> print(sentences.conll())
@@ -40,3 +40,6 @@ Drone.io Build Status: [![Drone.io Build Status](https://drone.io/github.com/aym
 
 [![Build status](https://ci.appveyor.com/api/projects/status/github/aymara/lima?branch=master&svg=true)](https://ci.appveyor.com/project/kleag/lima)
 [![GitHub Action Workflow status](https://github.com/aymara/lima/actions/workflows/build.yml/badge.svg)](https://github.com/aymara/lima/actions)
+
+
+[![LIMA Python Downloads](https://static.pepy.tech/personalized-badge/aymara?period=total&units=international_system&left_color=black&right_color=brightgreen&left_text=LIMA%20Python%20Downloads)](https://pepy.tech/project/aymara)

--- a/continuous_integration/Dockerfile-manylinux_2_24_lima-manylinux
+++ b/continuous_integration/Dockerfile-manylinux_2_24_lima-manylinux
@@ -1,9 +1,11 @@
 ARG PYTHON_VERSION="3.8"
-FROM aymara/manylinux_2_24_with_qt${QT_VERSION}-python${PYTHON_VERSION}:latest as aymara_manylinux_2_24_with_qt
-# FROM aymara/manylinux_2_24_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest as aymara_manylinux_2_24_with_qt_and_pyside
-
+ARG QT_VERSION="5.15"
+# FROM aymara/manylinux_2_24_with_qt${QT_VERSION}-python${PYTHON_VERSION}:latest as aymara_manylinux_2_24_with_qt
+FROM aymara/manylinux_2_24_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest as aymara_manylinux_2_24_with_qt_and_pyside
 FROM quay.io/pypa/manylinux_2_24_x86_64
 
+
+ARG GCC_VERSION=10.1.0
 ARG QT_VERSION_MAJOR="5"
 ARG QT_FULL_VERSION="5.15.2"
 ARG PYSIDE_VERSION="2"
@@ -29,10 +31,10 @@ ENV LC_ALL=en_US.UTF-8
 COPY --from=aymara/manylinux_2_24_with_icu:latest /usr/local /usr/local
 COPY --from=aymara/manylinux_2_24_with_nltk_data:latest /nltk_data /nltk_data
 COPY --from=aymara/manylinux_2_24_with_tensorflow_for_lima_1_9:latest /tensorflow_for_lima /usr/local
-# COPY --from=aymara_manylinux_2_24_with_qt_and_pyside /opt /opt
-# COPY --from=aymara_manylinux_2_24_with_qt_and_pyside /usr/local /usr/local
-COPY --from=aymara_manylinux_2_24_with_qt /opt /opt
-COPY --from=aymara_manylinux_2_24_with_qt /usr/local /usr/local
+COPY --from=aymara_manylinux_2_24_with_qt_and_pyside /opt /opt
+COPY --from=aymara_manylinux_2_24_with_qt_and_pyside /usr/local /usr/local
+# COPY --from=aymara_manylinux_2_24_with_qt /opt /opt
+# COPY --from=aymara_manylinux_2_24_with_qt /usr/local /usr/local
 
 ARG BRANCH=master
 ARG USE_TENSORFLOW="true"
@@ -55,9 +57,6 @@ RUN apt-get update -y -qq && apt-get install -y \
         gstreamer1.0-x \
         dos2unix
 
-ENV QTDIR=/opt/qt${QT_VERSION_MAJOR}
-ENV PATH=/opt/qt${QT_VERSION_MAJOR}/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MAJOR}/lib:$LD_LIBRARY_PATH
 
 WORKDIR /
 RUN wget -q https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.9.5.tar.xz
@@ -95,6 +94,15 @@ ENV PATH="/opt/_internal/cpython-${PYTHON_FULL_VERSION}/bin:/opt/python/cp${PYTH
 # install python packages necessary to use the language resources install script
 RUN /bin/bash -c "if [ \"$USE_TENSORFLOW\" = true ] ; then pip${PYTHON_VERSION} install arpy requests tqdm scikit-build pyside${PYSIDE_VERSION} shiboken${PYSIDE_VERSION} ; fi"
 
+ENV QTDIR=/opt/qt${QT_VERSION_MAJOR}
+
+ENV PATH=/opt/gcc-${GCC_VERSION}/bin:/opt/qt${QT_VERSION_MAJOR}/bin:/opt/qt${QT_VERSION_MAJOR}/${QT_FULL_VERSION}/gcc_64/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/gcc-${GCC_VERSION}/lib:/opt/gcc-${GCC_VERSION}/lib64:/opt/qt${QT_VERSION_MAJOR}/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/gcc-${GCC_VERSION}/share/man:$MANPATH \
+    INFOPATH=/opt/gcc-${GCC_VERSION}/share/info:$INFOPATH \
+    LLVM_INSTALL_DIR=/opt/llvm CLANG_INSTALL_DIR=/opt/llvm \
+    CC=/opt/gcc-${GCC_VERSION}/bin/gcc CXX=/opt/gcc-${GCC_VERSION}/bin/g++
+
 RUN mkdir -p /src/
 RUN git clone -v --branch=$BRANCH --recurse-submodules https://${GITHUB_TOKEN}@github.com/aymara/lima /src/lima
 WORKDIR /src/lima
@@ -131,5 +139,8 @@ RUN /bin/bash -c "set -o pipefail && tvx --language=eng --language=fre test-fre.
 #RUN /bin/bash -c "if [ \"$USE_TENSORFLOW\" = true ] ; then lima_models.py -l english ; fi"
 #RUN /bin/bash -c "if [ \"$USE_TENSORFLOW\" = true ] ; then lima_models.py -l french ; fi"
 
+# RUN pip install \
+#      --index-url=https://download.qt.io/official_releases/QtForPython/ \
+#      --trusted-host download.qt.io shiboken${PYSIDE_VERSION} pyside${PYSIDE_VERSION} shiboken${PYSIDE_VERSION}_generator
 
 WORKDIR /

--- a/continuous_integration/Dockerfile-manylinux_2_24_with_qt
+++ b/continuous_integration/Dockerfile-manylinux_2_24_with_qt
@@ -1,7 +1,8 @@
-ARG GCC_VERSION=10.1.0
-FROM aymara/manylinux_2_24_with_gcc${GCC_VERSION}:latest
+# ARG GCC_VERSION=10.1.0
+# FROM aymara/manylinux_2_24_with_gcc${GCC_VERSION}:latest
 # ARG LLVM_VERSION="14.0.6"
 # FROM aymara/manylinux_2_24_with_llvm${LLVM_VERSION}:latest
+FROM quay.io/pypa/manylinux_2_24_x86_64 AS manylinux_2_24_with_qt
 
 ARG GCC_VERSION=10.1.0
 # ARG LLVM_VERSION="14.0.6"
@@ -140,13 +141,13 @@ ENV SRC=/src
 
 RUN mkdir -p "$BUILD_TARGET"
 
-ENV PATH=/opt/gcc-${GCC_VERSION}/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/gcc-${GCC_VERSION}/lib:/opt/gcc-${GCC_VERSION}/lib64:$LD_LIBRARY_PATH
-ENV MANPATH=/opt/gcc-${GCC_VERSION}/share/man:$MANPATH
-ENV INFOPATH=/opt/gcc-${GCC_VERSION}/share/info:$INFOPATH
-
-ENV CC=/opt/gcc-${GCC_VERSION}/bin/gcc
-ENV CXX=/opt/gcc-${GCC_VERSION}/bin/g++
+# ENV PATH=/opt/gcc-${GCC_VERSION}/bin:$PATH
+# ENV LD_LIBRARY_PATH=/opt/gcc-${GCC_VERSION}/lib:/opt/gcc-${GCC_VERSION}/lib64:$LD_LIBRARY_PATH
+# ENV MANPATH=/opt/gcc-${GCC_VERSION}/share/man:$MANPATH
+# ENV INFOPATH=/opt/gcc-${GCC_VERSION}/share/info:$INFOPATH
+#
+# ENV CC=/opt/gcc-${GCC_VERSION}/bin/gcc
+# ENV CXX=/opt/gcc-${GCC_VERSION}/bin/g++
 # ENV CC=/opt/llvm/bin/clang
 # ENV CXX=/opt/llvm/bin/clang++
 # ENV LLVM_USE_LINKER=lld

--- a/continuous_integration/Dockerfile-manylinux_2_28_lima-manylinux
+++ b/continuous_integration/Dockerfile-manylinux_2_28_lima-manylinux
@@ -1,0 +1,96 @@
+ARG PYTHON_VERSION="3.8"
+ARG QT_VERSION="5.15"
+FROM aymara/manylinux_2_28_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest as aymara_manylinux_2_28_with_qt_and_pyside
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+
+ARG GCC_VERSION=10.1.0
+ARG QT_VERSION_MAJOR="5"
+ARG QT_FULL_VERSION="5.15.2"
+ARG PYSIDE_VERSION="2"
+ARG PYTHON_VERSION="3.8"
+ARG PYTHON_SHORT_VERSION="38"
+ARG PYTHON_FULL_VERSION="3.8.12"
+
+
+COPY --from=aymara/manylinux_2_28_with_nltk_data:latest /nltk_data /nltk_data
+COPY --from=aymara/manylinux_2_28_with_tensorflow_for_lima_1_9:latest /tensorflow_for_lima /usr/local
+COPY --from=aymara_manylinux_2_28_with_qt_and_pyside /opt /opt
+COPY --from=aymara_manylinux_2_28_with_qt_and_pyside /usr/local /usr/local
+
+ARG BRANCH=master
+ARG USE_TENSORFLOW="true"
+ARG GITHUB_TOKEN
+ARG LIMA_DISABLE_FSW_TESTING
+ARG LIMA_DISABLE_CPACK_DEBIAN_PACKAGE_SHLIBDEPS
+ARG NLTK_PTB_DP_FILE
+
+RUN yum install -y wget gcc-toolset-10.x86_64 ninja-build libicu-devel.x86_64 boost-devel.x86_64 qt5-devel.noarch
+
+ENV CC=/opt/rh/gcc-toolset-10/root/usr/bin/gcc \
+    CXX=/opt/rh/gcc-toolset-10/root/usr/bin/g++
+
+
+# WORKDIR /
+# RUN wget --no-check-certificate http://osmot.cs.cornell.edu/svm_light/current/svm_light.tar.gz -q
+# WORKDIR /svm_light
+# RUN tar xzf ../svm_light.tar.gz
+# RUN make
+# RUN cp svm_classify svm_learn /usr/bin
+# RUN rm -Rf /svm_light
+
+WORKDIR /
+
+# Those will have to be compiled for manylinux_2_28 instead of installed with the existing deb package
+# COPY svmtool.sh  svmtool-cpp.sh qhttpserver.sh /
+# RUN /svmtool.sh $GITHUB_TOKEN
+# RUN /svmtool-cpp.sh $GITHUB_TOKEN
+# RUN /qhttpserver.sh $GITHUB_TOKEN
+
+
+# install github-release to be able to deploy packages
+RUN wget https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 -q && tar xjf linux-amd64-github-release.tar.bz2 && cp bin/linux/amd64/github-release /usr/bin
+
+ENV PATH="/opt/_internal/cpython-${PYTHON_FULL_VERSION}/bin:/opt/python/cp${PYTHON_SHORT_VERSION}-cp${PYTHON_SHORT_VERSION}/bin:${PATH}"
+# install python packages necessary to use the language resources install script
+RUN /bin/bash -c "if [ \"$USE_TENSORFLOW\" = true ] ; then pip${PYTHON_VERSION} install arpy requests tqdm scikit-build pyside${PYSIDE_VERSION} shiboken${PYSIDE_VERSION} ; fi"
+
+RUN mkdir -p /src/
+RUN git clone -v --branch=$BRANCH --recurse-submodules https://${GITHUB_TOKEN}@github.com/aymara/lima /src/lima
+WORKDIR /src/lima
+ARG CACHEBUST=1
+RUN git pull
+RUN echo "$(git show -s --format=%cI HEAD | sed -e 's/[^0-9]//g')-$(git rev-parse --short HEAD)" > release
+
+RUN mkdir -p /src/lima/build
+WORKDIR /src/lima/build
+
+#ENV PERL5LIB /SVMTool-1.3.1/lib:$PERL5LIB
+#ENV PATH /SVMTool-1.3.1/bin:/usr/share/apps/lima/scripts:/usr/bin:$PATH
+ENV NLTK_PTB_DP_FILE=/nltk_data/corpora/dependency_treebank/nltk-ptb.dp \
+    LIMA_DISABLE_FSW_TESTING=true \
+    LIMA_DISABLE_CPACK_DEBIAN_PACKAGE_SHLIBDEPS=true \
+    LIMA_DIST=/opt/lima \
+    LIMA_CONF=/opt/lima/share/config/lima \
+    LIMA_RESOURCES=/opt/lima/share/apps/lima/resources \
+    PATH=/opt/lima/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/lima/lib:/opt/lima/lib64:${LD_LIBRARY_PATH}
+
+# Build
+#
+RUN cmake -G Ninja  -DQt${QT_VERSION_MAJOR}_DIR:PATH=/opt/qt${QT_VERSION_MAJOR}/${QT_FULL_VERSION}/gcc_64/lib/cmake/Qt${QT_VERSION_MAJOR} -DLIMA_RESOURCES:STRING=build -DCMAKE_INSTALL_PREFIX:PATH=/opt/lima -DCMAKE_BUILD_TYPE:STRING=Release -DLIMA_VERSION_RELEASE:STRING="$(cat /src/lima/release)" -DSHORTEN_POR_CORPUS_FOR_SVMLEARN:BOOL=ON -DTF_SOURCES_PATH:PATH="/tensorflow-for-lima-1.9/" -DWITH_DEBUG_MESSAGES=ON -DWITH_ARCH=OFF -DWITH_ASAN=OFF -DWITH_GUI=ON  ..
+RUN ninja && ninja install
+# && ninja package
+# RUN install -D -t /usr/share/apps/lima/packages /src/lima/build/*.
+
+WORKDIR /opt/lima/share/apps/lima/tests
+RUN /bin/bash -c "set -o pipefail && tva --language=eng test-eng.*.xml 2>&1 | tee tva-eng.log"
+RUN /bin/bash -c "set -o pipefail && tva --language=fre test-fre.default.xml test-fre.disambiguated.xml test-fre.hyphen.xml test-fre.idiom.xml test-fre.sa.xml test-fre.se.xml test-fre.simpleword.xml test-fre.tokenizer.xml 2>&1 | tee tva-fre.log"
+WORKDIR /opt/lima/share/apps/lima/tests/xmlreader
+RUN /bin/bash -c "set -o pipefail && tvx --language=eng --language=fre test-fre.xmlreader.xml 2>&1 | tee tvx-fre.log"
+#
+# ## install English and French UD models
+# #RUN /bin/bash -c "if [ \"$USE_TENSORFLOW\" = true ] ; then lima_models.py -l english ; fi"
+# #RUN /bin/bash -c "if [ \"$USE_TENSORFLOW\" = true ] ; then lima_models.py -l french ; fi"
+#
+WORKDIR /

--- a/continuous_integration/Dockerfile-manylinux_2_28_with_nltk_data
+++ b/continuous_integration/Dockerfile-manylinux_2_28_with_nltk_data
@@ -1,0 +1,25 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+# ENV DEBIAN_FRONTEND=noninteractive
+#
+# RUN apt-get clean && apt-get update && apt-get install -y locales
+# RUN echo "LC_ALL=en_US.UTF-8" > /etc/default/locale
+# RUN echo "LANG=en_US.UTF-8" >> /etc/default/locale
+# RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+# RUN cp  /etc/default/locale /etc/environment
+# RUN locale-gen
+# RUN dpkg-reconfigure locales
+# ENV LANG en_US.UTF-8
+# ENV LANGUAGE en_US:en
+# ENV LC_ALL en_US.UTF-8
+#
+# RUN apt-get update -y -qq && apt-get install -y python3-nltk libtre-dev gnupg libssl-dev nodejs
+# # Not available in manylinux: libenchant-2-dev npm
+RUN python3.7 -m pip install nltk
+
+WORKDIR /
+
+# RUN sed -ie "s|DEFAULT_URL = 'http://nltk.googlecode.com/svn/trunk/nltk_data/index.xml'|DEFAULT_URL = 'http://nltk.github.com/nltk_data/'|" /usr/lib/python*/*/nltk/downloader.py
+RUN python3.7 -m nltk.downloader -d nltk_data dependency_treebank
+RUN cat nltk_data/corpora/dependency_treebank/wsj_*.dp | grep -v "^$" > nltk_data/corpora/dependency_treebank/nltk-ptb.dp
+

--- a/continuous_integration/Dockerfile-manylinux_2_28_with_qt_and_pyside
+++ b/continuous_integration/Dockerfile-manylinux_2_28_with_qt_and_pyside
@@ -1,0 +1,36 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+ARG GCC_VERSION=10.1.0
+ARG QT_VERSION=5.15
+ARG QT_VERSION_MAJOR=5
+ARG QT_FULL_VERSION=5.15.2
+ARG PYSIDE_VERSION=2
+ARG PYTHON_VERSION="3.8"
+ARG PYTHON_SHORT_VERSION="cp38-cp38"
+ARG PYTHON_FULL_VERSION="3.8.13"
+
+ENV PATH="/opt/python/${PYTHON_SHORT_VERSION}/bin:${PATH}"
+
+RUN yum install -y wget gcc-toolset-10.x86_64 ninja-build libicu-devel.x86_64  "qt5-*.x86_64" qt5-devel.noarch \
+    clang.x86_64 python3-clang.x86_64 llvm-devel.x86_64 clang-devel.x86_64 libxml2-devel.x86_64 libxslt-devel.x86_64 \
+    python3-sphinx.noarch
+RUN ln -s /usr/bin/uic-qt5 /usr/bin/uic && \
+    ln -s /usr/bin/rcc-qt5 /usr/bin/rcc && \
+    ln -s /usr/lib64/libclang.so.13 /usr/lib64/libclang.so.1
+ENV CC=/opt/rh/gcc-toolset-10/root/usr/bin/gcc \
+    CXX=/opt/rh/gcc-toolset-10/root/usr/bin/g++
+
+RUN python${PYTHON_VERSION} -m pip install scikit-build
+
+# Install PySide${QT_VERSION_MAJOR} and shiboken${QT_VERSION_MAJOR} from source as binary installs are broken
+# Done in /home/gael/Logiciels/
+WORKDIR /
+RUN echo "Downloading https://download.qt.io/official_releases/QtForPython/pyside${PYSIDE_VERSION}/PySide${PYSIDE_VERSION}-${QT_FULL_VERSION}-src/pyside-setup-opensource-src-${QT_FULL_VERSION}.tar.xz" && wget -q https://download.qt.io/official_releases/QtForPython/pyside${PYSIDE_VERSION}/PySide${PYSIDE_VERSION}-${QT_FULL_VERSION}-src/pyside-setup-opensource-src-${QT_FULL_VERSION}.tar.xz && tar xf pyside-setup-opensource-src-${QT_FULL_VERSION}.tar.xz && mv /pyside-setup-opensource-src-${QT_FULL_VERSION} /pyside-setup && rm pyside-setup-opensource-src-${QT_FULL_VERSION}.tar.xz
+WORKDIR /pyside-setup
+RUN install -d /opt/_internal/cpython-${PYTHON_FULL_VERSION}/lib/x86_64-linux-gnu/ && touch /opt/_internal/cpython-${PYTHON_FULL_VERSION}/lib/x86_64-linux-gnu/libpython${PYTHON_VERSION}.a && touch /opt/_internal/cpython-${PYTHON_FULL_VERSION}/lib/x86_64-linux-gnu/libpython${PYTHON_VERSION}m.a
+
+WORKDIR /pyside-setup
+RUN python${PYTHON_VERSION} setup.py install --build-type=all --limited-api=yes
+WORKDIR /
+RUN rm -Rf /pyside-setup
+

--- a/continuous_integration/Dockerfile-manylinux_2_28_with_tensorflow_for_lima_1_9
+++ b/continuous_integration/Dockerfile-manylinux_2_28_with_tensorflow_for_lima_1_9
@@ -1,0 +1,43 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+# ENV DEBIAN_FRONTEND=noninteractive
+#
+# RUN apt-get clean && apt-get update && apt-get install -y locales
+# RUN echo "LC_ALL=en_US.UTF-8" > /etc/default/locale
+# RUN echo "LANG=en_US.UTF-8" >> /etc/default/locale
+# RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+# RUN cp  /etc/default/locale /etc/environment
+# RUN locale-gen
+# RUN dpkg-reconfigure locales
+# ENV LANG en_US.UTF-8
+# ENV LANGUAGE en_US:en
+# ENV LC_ALL en_US.UTF-8
+
+ARG BRANCH=master
+ARG USE_TENSORFLOW="true"
+ARG GITHUB_TOKEN
+ARG LIMA_DISABLE_FSW_TESTING
+ARG LIMA_DISABLE_CPACK_DEBIAN_PACKAGE_SHLIBDEPS
+ARG NLTK_PTB_DP_FILE
+
+# RUN apt-get update -y -qq && apt-get install -y git build-essential pkg-config automake wget cmake ninja-build
+RUN yum install -y wget gcc-toolset-10.x86_64
+
+ENV CC=/opt/rh/gcc-toolset-10/root/usr/bin/gcc \
+    CXX=/opt/rh/gcc-toolset-10/root/usr/bin/g++
+
+WORKDIR /
+RUN wget -q https://launchpad.net/~limapublisher/+archive/ubuntu/ppa/+sourcefiles/tensorflow-for-lima/1.9-ubuntu7~20.10/tensorflow-for-lima_1.9.orig.tar.xz
+RUN tar xf tensorflow-for-lima_1.9.orig.tar.xz
+RUN git clone -b r1.9 https://github.com/aymara/tensorflow.git
+RUN cp -r /tensorflow-for-lima-1.9/external /tensorflow
+WORKDIR /tensorflow
+RUN bash ./download_dependencies.sh
+WORKDIR /tensorflow/tensorflow
+RUN sed -ie "s|png/install/lib/libpng16.a|png/install/lib64/libpng16.a|" ./contrib/cmake/external/png.cmake
+RUN install -d /tensorflow/tensorflow-build
+WORKDIR /tensorflow/tensorflow-build
+RUN cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX=/tensorflow_for_lima ../tensorflow/contrib/cmake
+RUN make -C /tensorflow/tensorflow-build -j $(nproc) install
+# RUN make -C /tensorflow/tensorflow-build -j 1 install
+

--- a/continuous_integration/build_manylinux_2_28_lima-manylinux.sh
+++ b/continuous_integration/build_manylinux_2_28_lima-manylinux.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 CEA LIST <gael.de-chalendar@cea.fr>
+#
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+source python_env.sh
+docker build -f Dockerfile-manylinux_2_28_lima-manylinux --build-arg BRANCH="${BRANCH}" --build-arg QT_FULL_VERSION="${QT_FULL_VERSION}" --build-arg QT_VERSION_MAJOR="${QT_VERSION_MAJOR}" --build-arg QT_VERSION_MINOR="${QT_VERSION_MINOR}" --build-arg QT_VERSION_PATCH="${QT_VERSION_PATCH}" --build-arg QT_VERSION="${QT_VERSION}" --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PYTHON_SHORT_VERSION=${PYTHON_SHORT_VERSION} --build-arg PYTHON_FULL_VERSION=${PYTHON_FULL_VERSION} -t aymara/lima-manylinux_2_28-qt${QT_VERSION}-python${PYTHON_VERSION}:latest .
+docker push aymara/lima-manylinux_2_28-qt${QT_VERSION}-python${PYTHON_VERSION}:latest

--- a/continuous_integration/build_manylinux_2_28_with_nltk_data.sh
+++ b/continuous_integration/build_manylinux_2_28_with_nltk_data.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 CEA LIST <gael.de-chalendar@cea.fr>
+#
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+docker build --progress=plain -f Dockerfile-manylinux_2_28_with_nltk_data -t aymara/manylinux_2_28_with_nltk_data:latest .
+docker push aymara/manylinux_2_28_with_nltk_data:latest

--- a/continuous_integration/build_manylinux_2_28_with_qt_and_pyside.sh
+++ b/continuous_integration/build_manylinux_2_28_with_qt_and_pyside.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 CEA LIST <gael.de-chalendar@cea.fr>
+#
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+source python_env.sh
+docker build --progress=plain -f Dockerfile-manylinux_2_28_with_qt_and_pyside --build-arg QT_FULL_VERSION="${QT_FULL_VERSION}" --build-arg QT_VERSION_MAJOR="${QT_VERSION_MAJOR}" --build-arg QT_VERSION_MINOR="${QT_VERSION_MINOR}" --build-arg QT_VERSION_PATCH="${QT_VERSION_PATCH}" --build-arg QT_VERSION="${QT_VERSION}" --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PYTHON_SHORT_VERSION=${PYTHON_SHORT_VERSION} --build-arg PYTHON_FULL_VERSION=${PYTHON_FULL_VERSION} -t aymara/manylinux_2_28_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest .
+docker push aymara/manylinux_2_28_with_qt${QT_VERSION}_and_pyside-python${PYTHON_VERSION}:latest

--- a/continuous_integration/build_manylinux_2_28_with_tensorflow_for_lima_1_9.sh
+++ b/continuous_integration/build_manylinux_2_28_with_tensorflow_for_lima_1_9.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 CEA LIST <gael.de-chalendar@cea.fr>
+#
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+docker build --progress=plain -f Dockerfile-manylinux_2_28_with_tensorflow_for_lima_1_9 -t aymara/manylinux_2_28_with_tensorflow_for_lima_1_9:latest .
+docker push aymara/manylinux_2_28_with_tensorflow_for_lima_1_9:latest

--- a/continuous_integration/build_manylinux_lima-manylinux.sh
+++ b/continuous_integration/build_manylinux_lima-manylinux.sh
@@ -9,5 +9,5 @@ set -o pipefail
 set -o nounset
 
 source python_env.sh
-docker build -f Dockerfile-manylinux_2_24_lima-manylinux --build-arg QT_FULL_VERSION="${QT_FULL_VERSION}" --build-arg QT_VERSION_MAJOR="${QT_VERSION_MAJOR}" --build-arg QT_VERSION_MINOR="${QT_VERSION_MINOR}" --build-arg QT_VERSION_PATCH="${QT_VERSION_PATCH}" --build-arg QT_VERSION="${QT_VERSION}" --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PYTHON_SHORT_VERSION=${PYTHON_SHORT_VERSION} --build-arg PYTHON_FULL_VERSION=${PYTHON_FULL_VERSION} -t aymara/lima-manylinux_2_24-python${PYTHON_VERSION}:latest .
-docker push aymara/lima-manylinux_2_24-python${PYTHON_VERSION}:latest
+docker build -f Dockerfile-manylinux_2_24_lima-manylinux --build-arg BRANCH="${BRANCH}" --build-arg QT_FULL_VERSION="${QT_FULL_VERSION}" --build-arg QT_VERSION_MAJOR="${QT_VERSION_MAJOR}" --build-arg QT_VERSION_MINOR="${QT_VERSION_MINOR}" --build-arg QT_VERSION_PATCH="${QT_VERSION_PATCH}" --build-arg QT_VERSION="${QT_VERSION}" --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PYTHON_SHORT_VERSION=${PYTHON_SHORT_VERSION} --build-arg PYTHON_FULL_VERSION=${PYTHON_FULL_VERSION} -t aymara/lima-manylinux_2_24-qt${QT_VERSION}-python${PYTHON_VERSION}:latest .
+docker push aymara/lima-manylinux_2_24-qt${QT_VERSION}-python${PYTHON_VERSION}:latest

--- a/continuous_integration/python_env.sh
+++ b/continuous_integration/python_env.sh
@@ -7,6 +7,7 @@
 export GCC_VERSION="10.1.0"
 export LLVM_VERSION="14.0.6"
 
+export BRANCH="public_analysis_content"
 # QT_VERSION_PATCH >= 2
 # For python > 3.10, QT_VERSION_PATCH >= 6
 export QT_VERSION_MAJOR="5"
@@ -27,3 +28,29 @@ export PYTHON_WHEEL_VERSION="cp37-abi3"
 # For python 3.9, it is 3.9.13
 # For python 3.10, it is 3.10.5
 export PYTHON_FULL_VERSION="3.7.13"
+
+
+# export GCC_VERSION="10.1.0"
+# export LLVM_VERSION="14.0.6"
+#
+# export BRANCH="public_analysis_content"
+# # QT_VERSION_PATCH >= 2
+# # For python > 3.10, QT_VERSION_PATCH >= 6
+# export QT_VERSION_MAJOR="5"
+# export QT_VERSION_MINOR="15"
+# export QT_VERSION_PATCH="2"
+# export QT_VERSION="${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}"
+# export QT_FULL_VERSION="${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH}"
+# export PYSIDE_VERSION="2"
+# export PYTHON_VERSION="3.7"
+# # For python 3.7, it is cp37-cp37m
+# # For python 3.8, it is cp38-cp38
+# # For python 3.9, it is cp39-cp39
+# # For python 3.10, it is cp310-cp310
+# export PYTHON_SHORT_VERSION="cp37-cp37m"
+# export PYTHON_WHEEL_VERSION="cp37-abi3"
+# # For python 3.7, it is 3.7.13
+# # For python 3.8, it is 3.8.13
+# # For python 3.9, it is 3.9.13
+# # For python 3.10, it is 3.10.5
+# export PYTHON_FULL_VERSION="3.7.13"

--- a/lima_common/src/common/AbstractProcessingClient/AbstractProcessingClient.h
+++ b/lima_common/src/common/AbstractProcessingClient/AbstractProcessingClient.h
@@ -7,6 +7,7 @@
 #define LIMA_ABSTRACTPROCESSINGCLIENT_H
 
 #include "common/Handler/AbstractAnalysisHandler.h"
+#include "common/ProcessUnitFramework/AnalysisContent.h"
 #include "common/XMLConfigurationFiles/xmlConfigurationFileParser.h"
 #include <set>
 #include <deque>
@@ -22,18 +23,17 @@ public:
     //! @brief Define the destructor virtual to ensure concrete client destructors to be called
     virtual ~AbstractProcessingClient() {}
 
-    //! @brief analyze an image, given the pipeline and the expected resultType
-    //! @param content path of the file or text to analyze in string format
-    //! @param metaData additive information
-    //! @param pipeline analysis pipeline to use (an analysis pipeline is 
-
-    //!                      a chain of processUnit)
-    //! @param inactiveUnits ??? (un truc pour les texteux)
-    virtual void analyze(const std::string& content,
-                         const std::map<std::string,std::string>& metaData,
-                         const std::string& pipeline,
-                         const std::map<std::string, AbstractAnalysisHandler*>& handlers,
-                         const std::set<std::string>& inactiveUnits = std::set<std::string>()) const = 0;
+    //! @brief analyze a content, given the pipeline and the expected resultType
+    //! @param content path of the file or content to analyze in string format
+    //! @param metaData additional information
+    //! @param pipeline analysis pipeline to use (an analysis pipeline is a chain of processUnit)
+    //! @param inactiveUnits a set of pipeline units to skip during analysis
+    virtual std::shared_ptr<AnalysisContent> analyze(
+      const std::string& content,
+      const std::map<std::string,std::string>& metaData,
+      const std::string& pipeline,
+      const std::map<std::string, AbstractAnalysisHandler*>& handlers,
+      const std::set<std::string>& inactiveUnits = std::set<std::string>()) const = 0;
 
 };
 
@@ -75,7 +75,7 @@ public:
     std::deque<std::string> pipelines) = 0;
 
   /**
-   * This function create a LinguisticProcessing client 
+   * This function create a LinguisticProcessing client
    */
   virtual std::shared_ptr< AbstractProcessingClient > createClient() const = 0;
 

--- a/lima_linguisticprocessing/src/linguisticProcessing/client/AbstractLinguisticProcessingClient.h
+++ b/lima_linguisticprocessing/src/linguisticProcessing/client/AbstractLinguisticProcessingClient.h
@@ -11,13 +11,15 @@
 #define LIMA_LINGUISTICPROCESSING_ABSTRACTLINGUISTICANALYZERCLIENT_H
 
 #include "LinguisticProcessingClientExport.h"
-#include "common/Handler/AbstractAnalysisHandler.h"
 #include "LinguisticProcessingException.h"
-#include "common/XMLConfigurationFiles/xmlConfigurationFileParser.h"
-#include "common/Data/LimaString.h"
 #include "common/AbstractFactoryPattern/RegistrableFactory.h"
 #include "common/AbstractProcessingClient/AbstractProcessingClient.h"
+#include "common/Data/LimaString.h"
+#include "common/Handler/AbstractAnalysisHandler.h"
+#include "common/ProcessUnitFramework/AnalysisContent.h"
+#include "common/XMLConfigurationFiles/xmlConfigurationFileParser.h"
 
+#include <memory>
 
 namespace Lima
 {
@@ -55,7 +57,7 @@ public:
     *             functions to convert from UTF8 to/from LimaString
     *             are available in Lima::Common::Misc)
     * @param metaData some metadata used by the analyzer: the
-    *                 minimal metadata required is 
+    *                 minimal metadata required is
     *    - 'FileName' : filename (used to generate file log names)
     *    - 'Lang'     : language as string in a 3-letter format (following
     *                   the ISO 639-2 code): 'fre','eng',...
@@ -71,22 +73,24 @@ public:
     *                 LinguisticProcessingClientFactory.
     *
     */
-  virtual void analyze(const LimaString& text,
-                       const std::map<std::string,std::string>& metaData,
-                       const std::string& pipeline,
-                       const std::map<std::string, AbstractAnalysisHandler*>& handlers,
-                       const std::set<std::string>& inactiveUnits = std::set<std::string>()) const = 0;
+  virtual std::shared_ptr<AnalysisContent> analyze(
+                      const QString& text,
+                      const std::map<std::string,std::string>& metaData,
+                      const std::string& pipeline,
+                      const std::map<std::string, AbstractAnalysisHandler*>& handlers,
+                      const std::set<std::string>& inactiveUnits = std::set<std::string>()) const = 0;
 
   /**
     * This function is the same as the previous one but takes a text
     * in UTF-8 format
     *
     */
-  virtual void analyze(const std::string& text,
-                       const std::map<std::string,std::string>& metaData,
-                       const std::string& pipeline,
-                       const std::map<std::string, AbstractAnalysisHandler*>& handlers,
-                       const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override = 0;
+  virtual std::shared_ptr<AnalysisContent> analyze(
+                      const std::string& text,
+                      const std::map<std::string,std::string>& metaData,
+                      const std::string& pipeline,
+                      const std::map<std::string, AbstractAnalysisHandler*>& handlers,
+                      const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override = 0;
 };
 
 /**
@@ -126,7 +130,7 @@ public:
     std::deque<std::string> pipelines) override = 0;
 
   /**
-   * This function create a LinguisticProcessing client 
+   * This function create a LinguisticProcessing client
    */
   virtual std::shared_ptr< AbstractProcessingClient > createClient() const override = 0;
 
@@ -136,7 +140,7 @@ public:
   virtual ~AbstractLinguisticProcessingClientFactory() {};
 
 protected:
-  AbstractLinguisticProcessingClientFactory(const std::string& id) : 
+  AbstractLinguisticProcessingClientFactory(const std::string& id) :
     RegistrableFactory<AbstractLinguisticProcessingClientFactory>(id), AbstractProcessingClientFactory(id)
     {};
 
@@ -145,7 +149,7 @@ protected:
 //documentation for Doxygen main page
 /** @mainpage
  *
- * @section sec_principles Principles 
+ * @section sec_principles Principles
  *
  * The LIMA linguistic processing module is designed to work either
  * with a direct load of the dynamic libraries in the program or with
@@ -156,9 +160,9 @@ protected:
  *
  * The same API is also used either for analysis of simple text or for
  * analysis of structured XML documents.
- * 
+ *
  * @section sec_classes Main classes
- *  
+ *
  * AbstractLinguisticProcessingClient is the main class that
  * implements the generic LIMA API. Its main function to launch the
  * analysis on a text is AbstractLinguisticProcessingClient::analyze().
@@ -185,11 +189,11 @@ protected:
  *                    to an explicit configuration). This client uses
  *                    internally a core client to process the parts of
  *                    texts identified
- * 
+ *
  * @section How to call the LIMA analyzer
  *
- * To call the LIMA analyzer, one must indicate 
- * 
+ * To call the LIMA analyzer, one must indicate
+ *
  * - the name of a pipeline to be used, specifying the set of
  * processing units that are to be activated for the text analysis:
  * such pipelines and processing units are configured in the LIMA
@@ -199,7 +203,7 @@ protected:
  * - the handler, adapted to the chosen dumper, and specifying what to
  * do with this output (may be written to a file or stored in memory
  * for further processing...
- * 
+ *
  * The program analyzeText.cpp contains several examples of calls of
  * the LIMA analyze function. Here are some commented examples:
  *
@@ -213,14 +217,14 @@ protected:
  // here, we only configure the only elements that we want to use
  std::deque<std::string> langs(1,"fre");           // the configured languages
  std::deque<std::string> pipelines(1,"main");      // the configured pipelines
- 
+
  // the configuration file lima-analysis.xml containing all the configuration elements
- // for the different languages and pipelines is given as argument to the 
+ // for the different languages and pipelines is given as argument to the
  // client factory
  // Then, an analyzer client is created by the factory: here, we choose a
  // local client that will load the implementation of the analyzer in
  // dynamic libraries
- 
+
  AbstractLinguisticProcessingClient* client(0);
  XMLConfigurationFiles::XMLConfigurationFileParser lpconfig("conf/lima-analysis.xml");
  LinguisticProcessingClientFactory::changeable().configureClientFactory(
@@ -237,7 +241,7 @@ protected:
  map<string,string> metaData;
  metaData["Lang"]="fre"
  metaData["FileName"]="test.txt"
- 
+
  * @endcode
  *
  * @subsection sec_example_1 An example of call to analyze() with simple text output
@@ -256,7 +260,7 @@ protected:
 
  * @endcode
  *
- * @subsection sec_example_2 An example of call to analyze() with BoW output 
+ * @subsection sec_example_2 An example of call to analyze() with BoW output
  *
  * BoW is the LIMA binary format for an extended bag-of-words
  * representation, including compounds. This binary format is readable
@@ -264,8 +268,8 @@ protected:
  * representation of the format).
  *
  * @code
- 
- // for BoW output, we use a specific handler that handles the binary 
+
+ // for BoW output, we use a specific handler that handles the binary
  // format and write it to a file
 
 // ofstream fout("output.bin");

--- a/lima_linguisticprocessing/src/linguisticProcessing/client/xmlreader/AbstractXmlReaderClient.h
+++ b/lima_linguisticprocessing/src/linguisticProcessing/client/xmlreader/AbstractXmlReaderClient.h
@@ -36,11 +36,12 @@ public:
     //! @param pipeline TODO decrire
     //! @param resultType TODO decrire
     //! @param inactiveUnits TODO decrire
-    virtual void analyze(const std::string &content,
-                         const std::map<std::string, std::string>& metaData,
-                         const std::string& pipeline,
-                         const std::map<std::string, Lima::AbstractAnalysisHandler*>& handlers = std::map<std::string, Lima::AbstractAnalysisHandler*>(),
-                         const std::set<std::string>& inactiveUnits = std::set<std::string>())  const override = 0;
+    virtual std::shared_ptr<AnalysisContent> analyze(
+        const std::string &content,
+        const std::map<std::string, std::string>& metaData,
+        const std::string& pipeline,
+        const std::map<std::string, Lima::AbstractAnalysisHandler*>& handlers = std::map<std::string, Lima::AbstractAnalysisHandler*>(),
+        const std::set<std::string>& inactiveUnits = std::set<std::string>())  const override = 0;
 
     virtual void setAnalysisHandler(const std::string& handlerId, Lima::AbstractAnalysisHandler *handler) = 0;
 

--- a/lima_linguisticprocessing/src/linguisticProcessing/core/CoreLinguisticProcessingClient.cpp
+++ b/lima_linguisticprocessing/src/linguisticProcessing/core/CoreLinguisticProcessingClient.cpp
@@ -13,16 +13,17 @@
 
 #include "CoreLinguisticProcessingClient.h"
 
-#include "common/MediaticData/mediaticData.h"
-#include "common/XMLConfigurationFiles/xmlConfigurationFileExceptions.h"
 #include "common/Data/strwstrtools.h"
+#include "common/MediaProcessors/MediaProcessors.h"
+#include "common/MediaProcessors/MediaProcessUnitPipeline.h"
+#include "common/MediaticData/mediaticData.h"
+#include "common/ProcessUnitFramework/AnalysisContent.h"
+#include "common/XMLConfigurationFiles/xmlConfigurationFileExceptions.h"
 #include "common/time/timeUtilsController.h"
 #include "common/tools/FileUtils.h"
 #include "linguisticProcessing/LinguisticProcessingCommon.h"
 #include "linguisticProcessing/client/LinguisticProcessingClientFactory.h"
-#include "common/MediaProcessors/MediaProcessors.h"
 #include "linguisticProcessing/common/linguisticData/LimaStringText.h"
-#include "common/MediaProcessors/MediaProcessUnitPipeline.h"
 #include "linguisticProcessing/core/LinguisticProcessors/LinguisticMetaData.h"
 #include "linguisticProcessing/core/LinguisticResources/LinguisticResources.h"
 
@@ -60,21 +61,21 @@ CoreLinguisticProcessingClient::~CoreLinguisticProcessingClient()
   //LERROR << "CoreLinguisticProcessingClient::~CoreLinguisticProcessingClient()";
 }
 
-void CoreLinguisticProcessingClient::analyze(
-    const std::string& texte,
+std::shared_ptr<AnalysisContent> CoreLinguisticProcessingClient::analyze(
+    const std::string& text,
     const std::map<std::string,std::string>& metaData,
     const std::string& pipelineId,
     const std::map<std::string, AbstractAnalysisHandler*>& handlers,
     const std::set<std::string>& inactiveUnits) const
 
 {
-  LimaString limatexte=Common::Misc::utf8stdstring2limastring(texte);
+  auto limatext = QString::fromStdString(text);
 
-  analyze(limatexte,metaData,pipelineId,handlers,inactiveUnits);
+  return analyze(limatext, metaData, pipelineId, handlers, inactiveUnits);
 }
 
-void CoreLinguisticProcessingClient::analyze(
-    const LimaString& text,
+std::shared_ptr<AnalysisContent> CoreLinguisticProcessingClient::analyze(
+    const QString& text,
     const std::map<std::string,std::string>& metaData,
     const std::string& pipelineId,
     const std::map<std::string, AbstractAnalysisHandler*>& handlers,
@@ -89,20 +90,20 @@ void CoreLinguisticProcessingClient::analyze(
   QString whitespaceOnly("\\s*");
 
   whitespaceOnly = QRegularExpression::anchoredPattern(whitespaceOnly);
- if (QRegularExpression(whitespaceOnly).match(text).hasMatch())
- {
-   LWARN << "Empty text given to LIMA linguistic processing client. Nothing to do.";
-   return;
- }
+  auto analysis = std::make_shared<AnalysisContent>();
+  if (QRegularExpression(whitespaceOnly).match(text).hasMatch())
+  {
+    LWARN << "Empty text given to LIMA linguistic processing client. Nothing to do.";
+    return analysis;
+  }
 
   // create analysis content
-  AnalysisContent analysis;
   LinguisticMetaData* metadataholder=new LinguisticMetaData(); // will be destroyed in AnalysisContent destructor
-  analysis.setData("LinguisticMetaData",metadataholder);
+  analysis->setData("LinguisticMetaData",metadataholder);
 
   metadataholder->setMetaData(metaData);
   LimaStringText* lstexte=new LimaStringText(text); // will be destroyed in AnalysisContent destructor
-  analysis.setData("Text", lstexte);
+  analysis->setData("Text", lstexte);
 
   LINFO << "CoreLinguisticProcessingClient::analyze(";
   for(auto attrIt = metaData.cbegin() ; attrIt != metaData.cend() ; attrIt++ ) {
@@ -116,19 +117,20 @@ void CoreLinguisticProcessingClient::analyze(
     LDEBUG << "CoreLinguisticProcessingClient::analyze: no metadata";
   }
 #endif
-  for (map<string,string>::const_iterator it=metaData.begin(),
-         it_end=metaData.end(); it!=it_end; it++) {
-    if ((*it).first=="date") {
+  for (auto it=metaData.cbegin(), it_end=metaData.cend(); it!=it_end; it++)
+  {
+    if ((*it).first=="date")
+    {
       try {
-        const std::string& str=(*it).second;
-        uint64_t i=str.find("T"); //2006-12-11T12:44:00
+        const auto& str = (*it).second;
+        auto i = str.find("T"); //2006-12-11T12:44:00
         /*if (i!=std::string::npos) {
           QTime docTime=posix_time::time_from_string(str);
           metadataholder->setTime("document",docTime);
           LDEBUG << "use '"<< str << "' as document time";
           }*/
-        string date(str,0,i);
-        QDate docDate=QDate::fromString(date.c_str(),Qt::ISODate);
+        std::string date(str, 0, i);
+        auto docDate = QDate::fromString(date.c_str(),Qt::ISODate);
         metadataholder->setDate("document",docDate);
 
 #ifdef DEBUG_LP
@@ -136,31 +138,36 @@ void CoreLinguisticProcessingClient::analyze(
         LDEBUG << "use boost'"<< docDate.day() <<"/"<< docDate.month() <<"/"<< docDate.year() << "' as document date";
 #endif
       }
-      catch (std::exception& e) {
+      catch (std::exception& e)
+      {
         LERROR << "Error in date conversion (date '"<< (*it).second
                << "' will be ignored): " << e.what();
       }
     }
-    else if ((*it).first=="location") {
+    else if ((*it).first=="location")
+    {
       metadataholder->setLocation("document",(*it).second);
 #ifdef DEBUG_LP
         LDEBUG << "use '"<< (*it).second<< "' as document location";
 #endif
     }
-    else if ((*it).first=="time") {
+    else if ((*it).first=="time")
+    {
       try {
-        QTime docTime= QTime::fromString((*it).second.c_str(),"hh:mm:ss.z" );
+        auto docTime= QTime::fromString((*it).second.c_str(),"hh:mm:ss.z" );
         metadataholder->setTime("document",docTime);
 #ifdef DEBUG_LP
         LDEBUG << "use '"<< (*it).second<< "' as document time";
 #endif
       }
-      catch (std::exception& e) {
+      catch (std::exception& e)
+      {
         LERROR << "Error in ptime conversion (time '"<< (*it).second
                << "' will be ignored): " << e.what();
       }
     }
-    else if ((*it).first=="docid") {
+    else if ((*it).first=="docid")
+    {
 #ifdef DEBUG_LP
       LDEBUG << "use '"<< (*it).second<< "' as document id";
 #endif
@@ -183,7 +190,7 @@ void CoreLinguisticProcessingClient::analyze(
   // try to retrieve offset
   try
   {
-    const std::string& offsetStr=metadataholder->getMetaData("StartOffset");
+    const auto& offsetStr = metadataholder->getMetaData("StartOffset");
     metadataholder->setStartOffset(atoi(offsetStr.c_str()));
   }
   catch (LinguisticProcessingException& )
@@ -191,33 +198,34 @@ void CoreLinguisticProcessingClient::analyze(
     metadataholder->setStartOffset(0);
   }
 
-  const std::string& fileName=metadataholder->getMetaData("FileName");
+  const auto& fileName = metadataholder->getMetaData("FileName");
   // get language
-  const std::string& lang=metadataholder->getMetaData("Lang");
+  const auto& lang = metadataholder->getMetaData("Lang");
   LINFO  << "analyze file is: '" << fileName << "'";
   LINFO  << "analyze pipeline is '" << pipelineId << "'";
   LINFO  << "analyze language is '" << lang << "'";
 #ifdef DEBUG_LP
-  LDEBUG << "texte : " << text;
+  LDEBUG << "text : " << text;
 #endif
-  //LDEBUG << "texte : " << Common::Misc::limastring2utf8stdstring(texte);
+  //LDEBUG << "text : " << Common::Misc::limastring2utf8stdstring(texte);
 
-  MediaId langId=MediaticData::single().getMediaId(lang);
+  auto langId = MediaticData::single().getMediaId(lang);
 
   // get pipeline
-  const MediaProcessUnitPipeline* pipeline=MediaProcessors::single().getPipelineForId(langId,pipelineId);
-  if (pipeline==0)
+  auto pipeline = MediaProcessors::single().getPipelineForId(langId,pipelineId);
+  if (pipeline == nullptr)
   {
     LERROR << "can't get pipeline '" << pipelineId << "'";
-    throw LinguisticProcessingException( std::string("can't get pipeline '" + pipelineId + "' for language '" + lang + "'") );
+    throw LinguisticProcessingException(
+      std::string("can't get pipeline '" + pipelineId + "' for language '" + lang + "'") );
   }
   InactiveUnitsData* inactiveUnitsData = new InactiveUnitsData();
-  for (std::set<std::string>::const_iterator it = inactiveUnits.begin(); it != inactiveUnits.end(); it++)
+  for (auto inactiveUnit: inactiveUnits)
   {
 //     const_cast<MediaProcessUnitPipeline*>(pipeline)->setInactiveProcessUnit(*it);
-    inactiveUnitsData->insert(*it);
+    inactiveUnitsData->insert(inactiveUnit);
   }
-  analysis.setData("InactiveUnits", inactiveUnitsData);
+  analysis->setData("InactiveUnits", inactiveUnitsData);
 
   // add handler to analysis
 #ifdef DEBUG_LP
@@ -227,17 +235,17 @@ void CoreLinguisticProcessingClient::analyze(
     LDEBUG << "    " << (*hit).first << (*hit).second;
   }
 #endif
-  AnalysisHandlerContainer* h = new AnalysisHandlerContainer(const_cast<std::map<std::string, AbstractAnalysisHandler*>& >(handlers));
+  auto h = new AnalysisHandlerContainer(const_cast<std::map<std::string, AbstractAnalysisHandler*>& >(handlers));
 #ifdef DEBUG_LP
   LDEBUG << "set data" ;
 #endif
-  analysis.setData("AnalysisHandlerContainer", h);
+  analysis->setData("AnalysisHandlerContainer", h);
 
   // process analysis
 #ifdef DEBUG_LP
   LDEBUG << "Process pipeline..." ;
 #endif
-  LimaStatusCode status = pipeline->process(analysis);
+  auto status = pipeline->process(*analysis);
 #ifdef DEBUG_LP
   LDEBUG << "pipeline process returned status " << (int)status ;
 #endif
@@ -246,6 +254,7 @@ void CoreLinguisticProcessingClient::analyze(
       LIMA_LP_EXCEPTION( "analysis failed : receive status " << (int)status
                          << " from pipeline." );
   }
+  return analysis;
 }
 
 CoreLinguisticProcessingClientFactory::CoreLinguisticProcessingClientFactory() :
@@ -277,10 +286,9 @@ void CoreLinguisticProcessingClientFactory::configure(
   {
     try
     {
-      langToload=configuration.getModuleGroupListValues(
-                   "lima-coreclient",
-                   "mediaProcessingDefinitionFiles",
-                   "available");
+      langToload = configuration.getModuleGroupListValues("lima-coreclient",
+                                                          "mediaProcessingDefinitionFiles",
+                                                          "available");
     }
     catch (NoSuchList& )
     {
@@ -292,17 +300,17 @@ void CoreLinguisticProcessingClientFactory::configure(
   for (const auto& lang: langToload)
   {
     LINFO << "CoreLinguisticProcessingClientFactory::configure load language " << lang;
-    MediaId langid=MediaticData::single().getMediaId(lang);
+    auto langid = MediaticData::single().getMediaId(lang);
     QString file;
     try
     {
-      QStringList configPaths = QString::fromUtf8(Common::MediaticData::MediaticData::single().getConfigPath().c_str()).split(LIMA_PATH_SEPARATOR);
+      auto configPaths = QString::fromUtf8(Common::MediaticData::MediaticData::single().getConfigPath().c_str()).split(LIMA_PATH_SEPARATOR);
       if (configPaths.isEmpty())
       {
         LERROR << "no config paths available in MediaticData";
         throw InvalidConfiguration("no config paths available in MediaticData");
       }
-      QString mediaProcessingDefinitionFile = QString::fromUtf8(configuration.getModuleGroupParamValue(
+      auto mediaProcessingDefinitionFile = QString::fromUtf8(configuration.getModuleGroupParamValue(
             "lima-coreclient",
             "mediaProcessingDefinitionFiles",
             lang).c_str());
@@ -336,7 +344,7 @@ void CoreLinguisticProcessingClientFactory::configure(
     LINFO << "configure resources for language " << lang;
     try
     {
-      ModuleConfigurationStructure& module=langParser.getModuleConfiguration("Resources");
+      auto& module = langParser.getModuleConfiguration("Resources");
       LinguisticResources::changeable().initLanguage(
         langid,
         module,
@@ -352,7 +360,7 @@ void CoreLinguisticProcessingClientFactory::configure(
     LINFO << "initialize processors";
     try
     {
-      ModuleConfigurationStructure& procmodule=langParser.getModuleConfiguration("Processors");
+      auto& procmodule = langParser.getModuleConfiguration("Processors");
       MediaProcessors::changeable().initMedia(
         langid,
         procmodule/*,
@@ -369,7 +377,7 @@ void CoreLinguisticProcessingClientFactory::configure(
   LINFO << "initialize Pipelines";
   try
   {
-    GroupConfigurationStructure& group=configuration.getModuleGroupConfiguration("lima-coreclient","pipelines");
+    auto& group = configuration.getModuleGroupConfiguration("lima-coreclient","pipelines");
     MediaProcessors::changeable().initPipelines(group,pipelines);
   }
   catch (NoSuchModule& )

--- a/lima_linguisticprocessing/src/linguisticProcessing/core/CoreLinguisticProcessingClient.h
+++ b/lima_linguisticprocessing/src/linguisticProcessing/core/CoreLinguisticProcessingClient.h
@@ -9,6 +9,7 @@
 #include "CoreLinguisticProcessingClientExport.h"
 #include "linguisticProcessing/client/AbstractLinguisticProcessingClient.h"
 #include "common/Handler/AbstractAnalysisHandler.h"
+#include "common/ProcessUnitFramework/AnalysisContent.h"
 
 #include <list>
 
@@ -28,18 +29,19 @@ public:
 
   virtual ~CoreLinguisticProcessingClient();
 
-  void analyze(const LimaString& texte,
-               const std::map<std::string,std::string>& metaData,
-               const std::string& pipeline,
-               const std::map<std::string, AbstractAnalysisHandler*>& handlers,
-               const std::set<std::string>& inactiveUnits = std::set<std::string>()) const
-   override;
+  std::shared_ptr<AnalysisContent> analyze(
+    const QString& texte,
+    const std::map<std::string,std::string>& metaData,
+    const std::string& pipeline,
+    const std::map<std::string, AbstractAnalysisHandler*>& handlers,
+    const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override;
 
-  void analyze(const std::string& texte,
-               const std::map<std::string,std::string>& metaData,
-               const std::string& pipeline,
-               const std::map<std::string, AbstractAnalysisHandler*>& handlers,
-               const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override
+  std::shared_ptr<AnalysisContent> analyze(
+    const std::string& texte,
+    const std::map<std::string,std::string>& metaData,
+    const std::string& pipeline,
+    const std::map<std::string, AbstractAnalysisHandler*>& handlers,
+    const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override
   ;
 };
 

--- a/lima_linguisticprocessing/src/linguisticProcessing/core/CoreXmlReaderClient.cpp
+++ b/lima_linguisticprocessing/src/linguisticProcessing/core/CoreXmlReaderClient.cpp
@@ -256,7 +256,7 @@ void CoreXmlReaderClient::handleProperty(
 
 //!@brief analyse effective d'un fichier XML
 //! Fait appel a m_handler (type xmlDocumentHandler)
-void CoreXmlReaderClient::analyze(
+std::shared_ptr<AnalysisContent> CoreXmlReaderClient::analyze(
     const std::string &text,
     const std::map<std::string, std::string>& metaData,
     const std::string &pipeline,
@@ -323,6 +323,7 @@ void CoreXmlReaderClient::analyze(
      }
 #endif
      m_handler->endDocument();
+     return std::make_shared<AnalysisContent>();
 }
 
 void CoreXmlReaderClient::startNode(const DocumentsReader::ContentStructuredDocument &contentDocument, bool isIndexing)

--- a/lima_linguisticprocessing/src/linguisticProcessing/core/CoreXmlReaderClient.h
+++ b/lima_linguisticprocessing/src/linguisticProcessing/core/CoreXmlReaderClient.h
@@ -52,11 +52,12 @@ public:
     //! @param metaData TODO decrire
     //! @param pipeline TODO decrire
     //! @param inactiveUnits TODO decrire
-    void analyze(const std::string& content,
-                         const std::map<std::string,std::string>& metaData,
-                         const std::string& pipeline,
-                         const std::map<std::string, Lima::AbstractAnalysisHandler*>& handlers = std::map<std::string, Lima::AbstractAnalysisHandler*>(),
-                         const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override;
+    std::shared_ptr<AnalysisContent> analyze(
+        const std::string& content,
+        const std::map<std::string,std::string>& metaData,
+        const std::string& pipeline,
+        const std::map<std::string, Lima::AbstractAnalysisHandler*>& handlers = std::map<std::string, Lima::AbstractAnalysisHandler*>(),
+        const std::set<std::string>& inactiveUnits = std::set<std::string>()) const override;
 
     //! @brief associe un handler recupérant l'analyse XML
     void setAnalysisHandler(const std::string& handlerId, Lima::AbstractAnalysisHandler* handler) override;


### PR DESCRIPTION
* Update README.md

* Update README.md

* Update README.md

* Public analysis content (#142)

* Bump cmake version to the one from Ubuntu 20.04

* Errors on deprecated features removed from Qt6

Start to correct errors caused by this change.

* Activate manylinux with qt6 image build

* Correct typo

* Correct Qt configure

* Correct Qt configure command

* Qt6 build use Ninja

* Build llvm on actions

* Try push to docker hub

* New try

* Remove useless job

* Build llvm again

* Compile more LLVM projects

* Correct typo

* Correct llvm projects list

* Remove unknown llvm project

* Add gcc build

* LLVM build uses recent GCC

* Activate llvm build action

* Add missing ARG

* Correct gcc setting in llvm build

* Use for real recent gcc to build llvm

* Disable build llvm-libc as it fails with gcc

* Switch to building qt6

* Remove useless env var

* Compile qt with gcc

* Correct parent image name

* Correct gcc path

* Add missing login to docker hub

* Use strings for version numbers in env vars.

This avoids to accidentally change "3.10" in "3.1".

* Build PySide

* Add message

* Correct variable name

* Add Qt path to pyside setup command

* Add missing gcc version arg

* Forgot to copy gcc into container

* Correct docker image name

* Change Qt version

* Retrieve LLVM in Qt and PySide image

* Remove spurious diff  trace

* Remove traces of hard coded Qt5 in cmake files

* Update workflow

* Should correct pyside build

Force also the use of python limited api to be able to generate abi3
wheels.

* Do not build qt. It was successful

* Move setup of clang before its use

* From with args must be an as in the beginning

* Correction

* Try to avoid no space left on device in action

* Free diskspace on github actions

* Try again llvm with clang only

* Simplify dockerfile

* Do not need gcc

* Correct typo

* Add missing package in image

* Switch back to Qt5 and python 3.7

* Add missing package

* Add all previous packages

* Change

* Switch to c++17 for qt15

* Copy again gcc in the image

* Qt 5.12 uses make instead of cmake

* Correct a path

* Switch to clang

* Correct pyside2 build

* Remove pyside6 option

* Try another thing

* ...

* Remove standalone option

With it build fails. This is a known problem solved in PySide6. See
https://bugreports.qt.io/browse/PYSIDE-1699

* Client returns AnalysisContent

This will allow to develop API using internals of lima data, such as
python bindings. For this use case, depending on dumpers and handlers is
too much hurdle.

* Build public_analysis_content branch in actions

* New github action

* Do not build pyside image

* Remove llvm

* Must build with PySide

* Correct python version

* Pass the branch to the docker build command

* Correct typo

* Switch to manylinux_2_28

* Works locally