### PR TITLE
Fix layer-0 BiLSTM stride bug and 3 DP crashes

### DIFF
--- a/deeplima/include/deeplima/dumper_conllu.h
+++ b/deeplima/include/deeplima/dumper_conllu.h
@@ -80,7 +80,10 @@ bool dfs(int v, std::vector<uint32_t>& heads,  std::vector<int>& color,
     // std::cerr << "dfs " << v << ", " << heads << ", " << color << ", " << cycle_start << ", " << cycle_end << std::endl;
     color[v] = 1;
     auto u = heads[v];
-    if (u == 0)
+    // A predicted head can be out of range (>= number of tokens) when the model
+    // produces a bad arc; treat it like "no head" so the cycle walk never
+    // indexes color[]/heads[] out of bounds.
+    if (u == 0 || u >= heads.size())
     {
       color[v] = 2;
       return false;

--- a/deeplima/include/deeplima/eigen_wrp/bilstm.h
+++ b/deeplima/include/deeplima/eigen_wrp/bilstm.h
@@ -291,15 +291,23 @@ public:
       {
         if (0 == i)
         {
-          //const M input = input_matrix.block(0, input_begin, input_matrix.rows(), input_end - input_begin);
+          // Copy the input block into a dense, contiguous matrix BEFORE the
+          // product. input_matrix is the shared vectorizer tensor whose leading
+          // dimension is wider than the feature count, so a lazily-evaluated
+          // block (input_matrix.block(...)) in the Eigen product reads columns
+          // >0 at the wrong stride -> only column 0 is correct. Forcing a dense
+          // copy respects the stride. (Deeper layers use outputs[i-1], which is
+          // tightly allocated, so they were unaffected.)
+          const M input = input_matrix.block(0, input_begin, input_matrix.rows(),
+                                             input_end - input_begin);
           // Top rows - forward pass
           temp.topLeftCorner(hidden_size * 4, input_end - input_begin)
-              = (layer.fw.weight_ih * input_matrix.block(0, input_begin, input_matrix.rows(), input_end - input_begin)).colwise()
+              = (layer.fw.weight_ih * input).colwise()
                 + layer.fw.bias_ih;
 
           // Bottom rows - backward pass
           temp.bottomLeftCorner(hidden_size * 4, input_end - input_begin)
-              = (layer.bw.weight_ih * input_matrix.block(0, input_begin, input_matrix.rows(), input_end - input_begin)).colwise()
+              = (layer.bw.weight_ih * input).colwise()
                 + layer.bw.bias_ih;
         }
         else
@@ -325,7 +333,11 @@ public:
       c = V::Zero(hidden_size);
       backward_pass(hidden_size, layer.bw, temp, s, g_u, g_o, g_if, c, output, zero, 0, input_end - input_begin);
       wb->bw_c[i] = c;
-      wb->bw_h[i] = output.col(input_begin).bottomRows(hidden_size);
+      // output is written at LOCAL columns [0, input_end - input_begin); the
+      // backward hidden state at the first position is column 0, not the global
+      // accumulated offset input_begin (which overruns the matrix once several
+      // sentences have been processed). Matches the single-layer overload.
+      wb->bw_h[i] = output.col(0).bottomRows(hidden_size);
     }
 
     return 0;

--- a/deeplima/include/deeplima/nets/birnn_seq_cls.h
+++ b/deeplima/include/deeplima/nets/birnn_seq_cls.h
@@ -474,6 +474,17 @@ public:
 
     slot.m_output_begin = slot_begin;
     slot.m_input_begin = slot_begin;
+
+    // Restore this slot's full allocated capacity. set_slot_end() (called right
+    // after, on the DP path) overwrites m_output_end/m_input_end with the actual
+    // data end (count) so the dumper can read [m_output_begin, m_output_end).
+    // But m_output_end is *also* the capacity bound asserted in set_slot_end().
+    // Without restoring it here, reusing this buffer/slot for a later, longer
+    // token batch checks count against the stale (shrunken) end from the
+    // previous use -> assert in debug, silent buffer overrun (heap corruption)
+    // in release. The DP writes [slot_begin, count) with count <= m_slot_len.
+    slot.m_output_end = slot_begin + m_slot_len;
+    slot.m_input_end = slot_begin + m_slot_len;
   }
 
   inline void set_slot_end(uint32_t idx, uint64_t slot_end)


### PR DESCRIPTION
The deeplima neural dependency parser produced garbage output and crashed on real (multi-layer, multi-sentence) models. Four bugs in the header-only Eigen inference, found by replaying per-layer dumps through the torch model:

1. bilstm.h (quality bug): the multi-layer encoder multiplied weight_ih by input_matrix.block(...) used lazily in the Eigen product. The shared vectorizer tensor has a leading dimension wider than the feature count, so the strided block read columns past the first at the wrong offset - only the first token was correct, scrambling every parse. Copy the block into a dense matrix before the product (as the single-layer overload does). Deeper layers read the tightly-allocated previous output and were unaffected, so single-layer models hid the bug.

2. bilstm.h: the multi-layer backward pass stored bw_h from output.col(input_begin) - a global accumulated offset indexing a local [0,len) buffer, overrunning the matrix once sentences accumulate. Use column 0, matching the single-layer overload.

3. birnn_seq_cls.h: set_slot_end() overwrites m_output_end with the data count, but m_output_end is also the capacity bound it asserts. Reusing a buffer for a longer batch then asserts (debug) or overflows the heap (release). set_slot_begin() now restores the slot's full allocated capacity first.

4. dumper_conllu.h: a predicted head >= number of tokens indexed the cycle-detection vectors out of bounds. Treat an out-of-range head as "no head".