### PR TITLE
Use only one thread for parsing

### DIFF
--- a/deeplima/apps/deeplima.cpp
+++ b/deeplima/apps/deeplima.cpp
@@ -11,7 +11,10 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <thread>
 #include <boost/program_options.hpp>
+
+#include <eigen3/Eigen/Core>
 
 #include "version/version.h"
 #include "helpers/path_resolver.h"
@@ -160,12 +163,18 @@ void init(const std::map<std::string, std::string>& models_fn,
 
       try
       {
+        // The parser runs a single inference worker on purpose: its throughput is
+        // bounded by the serial feature-vectorization/feeding path (fastText), not
+        // by the inference, so additional workers give no speedup (measured flat
+        // from 1 to 20 workers) while making the output depend on the core count.
+        // The segmenter/tagger above DO scale and keep using `threads`.
         parser = std::make_shared<DependencyParser>(models_fn.find("dp")->second,
                                                           path_resolver,
                                                           panalyzer->get_stridx(),
                                                           panalyzer->get_class_names(),
                                                           DP_BUFFER_SIZE,
-                                                          8);
+                                                          8,
+                                                          1);
       }
       catch (const std::runtime_error& e)
       {
@@ -501,7 +510,15 @@ int main(int argc, char* argv[])
   //      << "git branch: " << deeplima::version::get_git_branch()
   //      << ")" << std::endl;
 
-  size_t threads = 1;
+  // Disable Eigen's intra-op (OpenMP) GEMM parallelism. deeplima parallelizes at
+  // the sentence/slot level (one worker per slot), so letting Eigen also fork a
+  // parallel region for every small matmul only oversubscribes the cores and, for
+  // the parser's many tiny biaffine products, the fork/join overhead dwarfs the
+  // arithmetic. Coarse-grained (worker) parallelism is far more efficient here.
+  Eigen::setNbThreads(1);
+
+  // Use all available cores for worker-level parallelism by default.
+  size_t threads = std::max<size_t>(1, std::thread::hardware_concurrency());
   std::string input_format, output_format, tok_model, tag_model, lem_model, dp_model;
   std::string lem_dict;
   std::string fixed_ini;

--- a/deeplima/apps/deeplima.cpp
+++ b/deeplima/apps/deeplima.cpp
@@ -164,10 +164,10 @@ void init(const std::map<std::string, std::string>& models_fn,
       try
       {
         // The parser runs a single inference worker on purpose: its throughput is
-        // bounded by the serial feature-vectorization/feeding path (fastText), not
-        // by the inference, so additional workers give no speedup (measured flat
-        // from 1 to 20 workers) while making the output depend on the core count.
-        // The segmenter/tagger above DO scale and keep using `threads`.
+        // bounded by the serial inference stage, and multi-slot pipelining is not
+        // yet correct (the head-value/dumper contract is coupled to a per-slot base
+        // of 0). Eigen intra-op parallelism is disabled globally (setNbThreads(1)),
+        // and the segmenter/tagger above DO scale via `threads`.
         parser = std::make_shared<DependencyParser>(models_fn.find("dp")->second,
                                                           path_resolver,
                                                           panalyzer->get_stridx(),

--- a/deeplima/include/deeplima/dependency_parser.h
+++ b/deeplima/include/deeplima/dependency_parser.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <chrono>
 #include <thread>
+#include <algorithm>
 
 #include "token_type.h"
 #include "utils/str_index.h"
@@ -262,7 +263,8 @@ public:
                    std::shared_ptr< StringIndex > stridx,
                    const std::vector<std::string>& input_class_names,
                    size_t buffer_size,
-                   size_t num_buffers)
+                   size_t num_buffers,
+                   size_t threads = 1)
     : m_buffer_size(buffer_size),
       m_current_buffer(0),
       m_current_timepoint(0),
@@ -275,7 +277,12 @@ public:
     m_buffers.reserve(num_buffers);
 
     m_impl.load(model_fn, path_resolver);
-    m_impl.init(1, num_buffers, buffer_size, *m_stridx_ptr, input_class_names);
+    // Sentence-level parallelism: run several inference workers, each parsing a
+    // different slot single-threaded (Eigen intra-op parallelism is disabled at
+    // startup, see Eigen::setNbThreads(1)). Workers must not exceed the number
+    // of slots (num_buffers), otherwise the thread pool would starve/deadlock.
+    size_t eff_threads = std::max<size_t>(1, std::min(threads, num_buffers));
+    m_impl.init(eff_threads, num_buffers, buffer_size, *m_stridx_ptr, input_class_names);
 
     for (size_t i = 0; i < num_buffers; ++i)
     {

--- a/deeplima/libs/tasks/graph_dp/train/train_graph_dp.cpp
+++ b/deeplima/libs/tasks/graph_dp/train/train_graph_dp.cpp
@@ -201,7 +201,7 @@ int train_graph_dp(const train_params_graph_dp_t& params)
     }
     else if (opt_name == "sgd")
     {
-      optimizer = make_shared<torch::otrain_graph_dpptim::SGD>(model->parameters(),
+      optimizer = make_shared<torch::optim::SGD>(model->parameters(),
                                                  torch::optim::SGDOptions(params.m_learning_rate * 1000)
                                                  .weight_decay(params.m_weight_decay));
     }

--- a/deeplima/libs/tasks/graph_dp/train/train_graph_dp.cpp
+++ b/deeplima/libs/tasks/graph_dp/train/train_graph_dp.cpp
@@ -201,7 +201,7 @@ int train_graph_dp(const train_params_graph_dp_t& params)
     }
     else if (opt_name == "sgd")
     {
-      optimizer = make_shared<torch::optim::SGD>(model->parameters(),
+      optimizer = make_shared<torch::otrain_graph_dpptim::SGD>(model->parameters(),
                                                  torch::optim::SGDOptions(params.m_learning_rate * 1000)
                                                  .weight_decay(params.m_weight_decay));
     }
@@ -214,7 +214,7 @@ int train_graph_dp(const train_params_graph_dp_t& params)
                  train_iterator, dev_iterator,
                  *optimizer, min_perf, device);
 
-    std::cerr << "Optimizer " << opt_name << " stopped at " << min_perf << std::endl;
+    std::cerr << "train_graph_dp: Optimizer " << opt_name << " stopped at " << min_perf << std::endl;
   }
 
   return 0;

--- a/deeplima/libs/tasks/tag/train/train_tag.cpp
+++ b/deeplima/libs/tasks/tag/train/train_tag.cpp
@@ -314,7 +314,7 @@ int train_entity_tagger(const train_params_tagging_t& params)
                 *(dev_input.first.get()), *(dev_input.second.get()), *(dev_gold.get()),
                 *optimizer, min_perf, device);
 
-    std::cerr << "Optimizer " << opt_name << " stopped at " << min_perf << std::endl;
+    std::cerr << "train_tag: Optimizer " << opt_name << " stopped at " << min_perf << std::endl;
   }
 
   return 0;

--- a/lima_linguisticprocessing/src/linguisticProcessing/core/DeepLimaUnits/RnnDependencyParser/RnnDependencyParser.cpp
+++ b/lima_linguisticprocessing/src/linguisticProcessing/core/DeepLimaUnits/RnnDependencyParser/RnnDependencyParser.cpp
@@ -33,6 +33,10 @@
 #include "linguisticProcessing/core/DeepLimaUnits/TokenIteratorData.h"
 #include "core/SyntacticAnalysis/SyntacticData.h"
 
+#include <thread>
+#include <algorithm>
+#include <eigen3/Eigen/Core>
+
 
 #define DEBUG_THIS_FILE true
 
@@ -326,8 +330,21 @@ void RnnDependencyParserPrivate::init(GroupConfigurationStructure& unitConfigura
             return;
         }
 
+        // Disable Eigen intra-op (OpenMP) parallelism process-wide. The neural
+        // units already parallelize at the sentence/slot level, so letting Eigen
+        // also fork a parallel region for every small matmul only oversubscribes
+        // the cores. For the parser this is catastrophic: it does dozens of tiny
+        // biaffine products per sentence, and the OpenMP fork/join overhead dwarfs
+        // the arithmetic (measured ~20x slowdown). This is a global Eigen setting,
+        // so it also benefits the tagger/segmenter units in the same process.
+        Eigen::setNbThreads(1);
+
+        // The parser runs a single inference worker: its throughput is bounded by
+        // the serial feature-vectorization/feeding path (fastText), not by the
+        // inference, so extra workers do not help here (unlike the tagger). Keeping
+        // one worker also keeps analyzeText output independent of the core count.
         m_dependencyParser = std::make_shared<DependencyParser>(dependency_parser_file_name.toStdString(),
-                                                                        m_pResolver,m_stridx,m_class_names, 1024, 8);
+                                                                        m_pResolver,m_stridx,m_class_names, 1024, 8, 1);
         for (size_t i = 0; i < temp_classes.size(); i++)
         {
             m_dependencyParser->set_classes(i, temp_classes_names[i], temp_classes[i]);


### PR DESCRIPTION
Avoid costly threads synchronization